### PR TITLE
add a second callback argument and a config validator

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ class NeatScroll {
   }
 
   get speed() {
-    return this._speed || NeatScroll.config.speed
+    return typeof this._speed === 'number' && this._speed > 0 
+      ? this._speed
+      : NeatScroll.config.speed
   }
 
   set speed(value) {
@@ -50,7 +52,9 @@ class NeatScroll {
   }
 
   get smooth() {
-    return this._smooth || NeatScroll.config.smooth
+    return typeof this._smooth === 'number' && this._smooth > 0 
+      ? this._smooth
+      : NeatScroll.config.smooth
   }
 
   set smooth(value) {
@@ -93,9 +97,13 @@ class NeatScroll {
     } else {
       this.scrollPosition += delta
       this.lastDelta = decimalDelta
-      requestAnimationFrame(()=>this.update())
+      requestAnimationFrame(() => this.update())
     }
-    this.callback(this.target)
+    this.callback(this.target, {
+      scrollPosition: this.scrollPosition,
+      scrollLength: this.scrollLength,
+      clientLength: this.clientLength,
+    })
   }
 
   scrollByDelta(delta, smoothing = true) {


### PR DESCRIPTION
- 增加了 callback 函数的第二个参数，一个包含`scrollPosition`，`scrollLength`和`clientLength`属性的对象，用于更好地体现当前位置。（目前这么改是为了防止 breaking change，但在未来的大版本中或许可以取消第一个参数，改为返回对象的`el`属性？）
- 增加了`speed`和`smooth`两个属性在 getter 中的验证，防止由于未知错误导致的计算崩溃。